### PR TITLE
Improve dev by exposing port and mounting volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ build:
 
 .PHONY: dev
 dev:
-	docker run -it --env-file .env --rm $(IMAGE_NAME) /bin/bash
+	docker run -it --env-file .env -p 50051:50051 --rm -v `pwd`:/usr/src/app $(IMAGE_NAME) /bin/bash


### PR DESCRIPTION
### Purpose
Make it easier to run the server locally for development. This will allow faster restarts without needing to rebuild the container to see changes when testing the entire workflow with https://github.com/bufferapp/buffer-js-buffermetrics.

### Notes
If we like this we can add this to the development section of the README. I use this way for development. 

```shell
$ make build
...
$ make dev
docker run -it --env-file .env -p 50051:50051 --rm -v `pwd`:/usr/src/app bufferapp/events-collector:0.2.0 /bin/bash
root@a02093256168:/usr/src/app#
```
After running `make dev` we have a shell to just run `python -u server.py` and ctrl+c to kill the server to restart for file changes.

```
root@a02093256168:/usr/src/app# python -u server.py
INFO:root:Server initialized
INFO:botocore.credentials:Found credentials in environment variables.
INFO:root:Servicer added
INFO:root:Server started
```

### Review
What do you think @davidgasquez and @michael-erasmus ?