### PR TITLE
Use Kiner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3
 https://github.com/bufferapp/buda-protobufs/releases/download/0.4.3/buda-python-0.4.3.tar.gz
+kiner


### PR DESCRIPTION
Hey there @michael-erasmus! Starting this PR after what we briefly discussed yesterday! Seems it's forking fine but there're a few things to keep in mind:

- Each stream will have it's own Kiner producer with their own queue and thread pool.
- Right now, Kiner doesn't allow scheduled queue flushing (each 5 seconds) so the records stay in the queue until they reach the batch size or it's flushed with `close()`. I had a version with this feature working but decided to remove it since I assumed the records would come infinitely 😅. I'll revisit this next week. (https://github.com/bufferapp/kiner/issues/1)
- Right now, closing the server flushed the queue but if this is going to run in Kubernetes we'll need to handle the `SIGTERM` signal.

As always, feedback or thoughts appreciated!