### PR TITLE
Add debug output during dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ push:
 
 .PHONY: dev
 dev:
-	docker run -it --env-file .env -p 50051:50051 --rm -v `pwd`:/usr/src/app $(IMAGE_NAME) /bin/bash
+	docker run -it -e ENV=dev --env-file .env -p 50051:50051 --rm -v `pwd`:/usr/src/app $(IMAGE_NAME) /bin/bash
 
 .PHONY: deploy
 deploy: build push

--- a/server.py
+++ b/server.py
@@ -6,6 +6,7 @@ import grpc
 import logging
 from kiner.producer import KinesisProducer
 import signal
+import os
 
 from buda.services.events_collector_service_pb2 import Response
 import buda.services.events_collector_service_pb2_grpc as collector_grpc
@@ -50,6 +51,8 @@ class EventsCollectorServicer(collector_grpc.EventsCollectorServicer):
                 .format(name))
 
         data = message.SerializeToString()
+        if os.getenv('ENV', 'prod') == 'dev':
+            logger.info(data)
         self.producers[name].put_record(data)
 
     def CollectFunnelEvent(self, funnel_event, context):


### PR DESCRIPTION
### Purpose
When testing with [buffer-js-buffermetrics](https://github.com/bufferapp/buffer-js-buffermetrics), it's helpful to check sometimes whether the protobuf was correctly received with all data by the collector 😉 

### Notes
I'm not sure if this is a great Python convention so I'm happy to change this if there is a better convention to use!

The output isn't super great (see example below), but it works to be somewhat readable:
```
INFO:root:b'\n\x15\n\x139999999999999999999\x12\x0e\n\x0csomefunnelid\x1a\x10\n\x0eourfunnelstep!"\x12\n\x105678976543456789*\x06\x08\xb2\xda\xc1\xe3\x052\x14\n\x07tag-key\x12\ttag-value'
```