### PR TITLE
Use a queue instead of a list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_NAME:=bufferapp/events-collector:0.6.3
+IMAGE_NAME:=bufferapp/events-collector:0.6.4
 EXTRA_FLAGS = -v $(HOME)/.aws:/root/.aws -e ENV=dev -v ~/.config/gcloud/:/root/.config/gcloud
 
 .DEFAULT_GOAL := run

--- a/kubernetes/events-collector.deployment.yaml
+++ b/kubernetes/events-collector.deployment.yaml
@@ -25,7 +25,7 @@ spec:
                       secretName: bigquery-key
             containers:
                 - name: events-collector
-                  image: bufferapp/events-collector:0.6.3
+                  image: bufferapp/events-collector:0.6.4
                   imagePullPolicy: Always
                   volumeMounts:
                       - name: bigquery-google-cloud-credentials


### PR DESCRIPTION
The data collection is working properly with only 1 thread (same amount of [actions taken in Redshift](https://looker.buffer.com/sql/ykpjfgfy7qskgc) than [in BigQuery during 30 minutes](https://looker.buffer.com/sql/whzk5k5ytj6qmk)). I think we can use a Queue to handle atomic operations between threads to fix #25.